### PR TITLE
fix(docs): format + naming error in help tags

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -10,5 +10,5 @@ gomove-quickstart	nvim-gomove.txt	/*gomove-quickstart*
 gomove-usage	nvim-gomove.txt	/*gomove-usage*
 gomove_ignore_indent_lh_dup	nvim-gomove.txt	/*gomove_ignore_indent_lh_dup*
 gomove_map_defaults	nvim-gomove.txt	/*gomove_map_defaults*
-gomove_move_past_end_col nvim-gomove.txt	/*gomove_move_end_col*
+gomove_move_past_end_col	nvim-gomove.txt	/*gomove_move_past_end_col*
 gomove_reindent_mode	nvim-gomove.txt	/*gomove_reindent_mode*


### PR DESCRIPTION
noticed a formatting + naming error in the help tags caused by https://github.com/booperlv/nvim-gomove/commit/3e9dff937e450bbd617f10832c9659707206c91e

It was causing some issues with the `cmp-cmdline` as well as the `Telescope help_tags` auto completion.

I'm not super familiar with creating help tags but it looks like the spaces between each column in the file needs to be `<TAB>` specifically and not any other whitespace; `:h tags-file-format`.